### PR TITLE
启动的时候只加载指定爬虫

### DIFF
--- a/project/src/main/java/cn/wanghaomiao/seimi/core/Seimi.java
+++ b/project/src/main/java/cn/wanghaomiao/seimi/core/Seimi.java
@@ -34,6 +34,11 @@ import java.util.Map;
  * @since 2015/10/16.
  */
 public class Seimi extends SeimiContext {
+	
+	public Seimi(String... crawlerNames) {
+		super(crawlerNames);
+	}
+	
     /**
      * 主启动
      * start master

--- a/project/src/main/java/cn/wanghaomiao/seimi/core/SeimiContext.java
+++ b/project/src/main/java/cn/wanghaomiao/seimi/core/SeimiContext.java
@@ -117,6 +117,10 @@ public class SeimiContext  extends AnnotationConfigApplicationContext {
     }
     
     private boolean isNeededInit(String crawlerName, String... crawlerNames) {
+    	if (crawlerNames == null && crawlerName.length() == 0) {
+			return true;
+		}
+    	
     	for (String name : crawlerNames) {
 			if (crawlerName.equals(name)) {
 				return true;

--- a/project/src/main/java/cn/wanghaomiao/seimi/core/SeimiContext.java
+++ b/project/src/main/java/cn/wanghaomiao/seimi/core/SeimiContext.java
@@ -23,6 +23,8 @@ import cn.wanghaomiao.seimi.def.BaseSeimiCrawler;
 import cn.wanghaomiao.seimi.exception.SeimiInitExcepiton;
 import cn.wanghaomiao.seimi.struct.CrawlerModel;
 import cn.wanghaomiao.seimi.utils.StrFormatUtil;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -56,9 +58,9 @@ public class SeimiContext  extends AnnotationConfigApplicationContext {
     protected Map<String,CrawlerModel> crawlerModelContext;
     protected ExecutorService workersPool;
     protected Logger logger = LoggerFactory.getLogger(getClass());
-    public SeimiContext(){
+    public SeimiContext(String... crawlerNames){
         register(ScanConfig.class);
-        init();
+        init(crawlerNames);
         if(!CollectionUtils.isEmpty(crawlers)){
             prepareCrawlerModels();
             workersPool = Executors.newFixedThreadPool(BASE_THREAD_NUM*Runtime.getRuntime().availableProcessors()*crawlers.size());
@@ -68,7 +70,7 @@ public class SeimiContext  extends AnnotationConfigApplicationContext {
         }
     }
 
-    private void init(){
+    private void init(String... crawlerNames){
         String[] targetPkgs = {"crawlers","queues","interceptors","cn.wanghaomiao.seimi"};
         seimiScanner = new SeimiScanner(this);
         Set<Class<?>> aladdin = seimiScanner.scan(targetPkgs, Crawler.class, Queue.class, Interceptor.class);
@@ -81,9 +83,12 @@ public class SeimiContext  extends AnnotationConfigApplicationContext {
         for (Class cls:aladdin){
             if (BaseSeimiCrawler.class.isAssignableFrom(cls)){
                 Crawler c = (Crawler) cls.getAnnotation(Crawler.class);
-                hasUsedQuene.add(c.queue());
-                crawlers.add(cls);
-                registList.add(cls);
+                String crawlerName = StringUtils.isBlank(c.name()) ? cls.getSimpleName() : c.name();
+                if (isNeededInit(crawlerName, crawlerNames)) {
+                	hasUsedQuene.add(c.queue());
+                	crawlers.add(cls);
+                	registList.add(cls);
+				}
             }else if (SeimiInterceptor.class.isAssignableFrom(cls)){
                 registList.add(cls);
             }
@@ -110,6 +115,16 @@ public class SeimiContext  extends AnnotationConfigApplicationContext {
             }
         });
     }
+    
+    private boolean isNeededInit(String crawlerName, String... crawlerNames) {
+    	for (String name : crawlerNames) {
+			if (crawlerName.equals(name)) {
+				return true;
+			}
+		}
+    	return false;
+    }
+    
 
     private void prepareCrawlerModels(){
         for (Class<? extends BaseSeimiCrawler> a:crawlers){


### PR DESCRIPTION
之前的做法是扫描crawlers包下面所有爬虫加载到context中，但是有些并不想加载的爬虫会对环境造成影响。

比如一个爬虫指定redis作为queue而另一个用defaultqueue，如果只启动第二爬虫的话，在没有redis环境下也会报出could not get resource from the pool。

现在把Seimi及SeimiContext的构造器改为有参构造，这样可以在注册类的时候屏蔽掉那些不想启动的爬虫。