### PR TITLE
Request 与 Response 中的 meta 变量变成 Map<String, Object> 类型方便传值

### DIFF
--- a/project/src/main/java/cn/wanghaomiao/seimi/struct/Request.java
+++ b/project/src/main/java/cn/wanghaomiao/seimi/struct/Request.java
@@ -52,7 +52,7 @@ public class Request extends CommonObject {
     public Request(String url, String callBack,int maxReqCount) {
         this.url = url;
         this.callBack = callBack;
-        this.maxReqCount = this.maxReqCount;
+        this.maxReqCount = maxReqCount;
     }
 
     public static Request build(String url, String callBack, HttpMethod httpMethod, Map<String, String> params, Map<String, Object> meta){

--- a/project/src/main/java/cn/wanghaomiao/seimi/struct/Request.java
+++ b/project/src/main/java/cn/wanghaomiao/seimi/struct/Request.java
@@ -29,7 +29,7 @@ import java.util.Map;
  *         Date:  14-7-7.
  */
 public class Request extends CommonObject {
-    public Request(String url, String callBack, HttpMethod httpMethod, Map<String, String> params, Map<String, String> meta,int maxReqCount) {
+    public Request(String url, String callBack, HttpMethod httpMethod, Map<String, String> params, Map<String, Object> meta,int maxReqCount) {
         this.url = url;
         this.httpMethod = httpMethod;
         this.params = params;
@@ -37,7 +37,7 @@ public class Request extends CommonObject {
         this.callBack = callBack;
         this.maxReqCount = maxReqCount;
     }
-    public Request(String url, String callBack, HttpMethod httpMethod, Map<String, String> params, Map<String, String> meta) {
+    public Request(String url, String callBack, HttpMethod httpMethod, Map<String, String> params, Map<String, Object> meta) {
         this.url = url;
         this.httpMethod = httpMethod;
         this.params = params;
@@ -55,10 +55,10 @@ public class Request extends CommonObject {
         this.maxReqCount = this.maxReqCount;
     }
 
-    public static Request build(String url, String callBack, HttpMethod httpMethod, Map<String, String> params, Map<String, String> meta){
+    public static Request build(String url, String callBack, HttpMethod httpMethod, Map<String, String> params, Map<String, Object> meta){
         return new Request(url, callBack, httpMethod, params, meta);
     }
-    public static Request build(String url, String callBack, HttpMethod httpMethod, Map<String, String> params, Map<String, String> meta,int maxReqcount){
+    public static Request build(String url, String callBack, HttpMethod httpMethod, Map<String, String> params, Map<String, Object> meta,int maxReqcount){
         return new Request(url, callBack, httpMethod, params, meta, maxReqcount);
     }
 
@@ -91,7 +91,7 @@ public class Request extends CommonObject {
     /**
      * 这个主要用于存储向下级回调函数传递的一些自定义数据
      */
-    private Map<String,String> meta;
+    private Map<String,Object> meta;
     /**
      * 回调函数方法名
      */
@@ -176,7 +176,7 @@ public class Request extends CommonObject {
         return this;
     }
 
-    public Map<String, String> getMeta() {
+    public Map<String, Object> getMeta() {
         //保证用起来时可定不为空，方便使用
         if (meta == null){
             meta = new HashMap<>();
@@ -184,7 +184,7 @@ public class Request extends CommonObject {
         return meta;
     }
 
-    public Request setMeta(Map<String, String> meta) {
+    public Request setMeta(Map<String, Object> meta) {
         this.meta = meta;
         return this;
     }

--- a/project/src/main/java/cn/wanghaomiao/seimi/struct/Response.java
+++ b/project/src/main/java/cn/wanghaomiao/seimi/struct/Response.java
@@ -42,7 +42,7 @@ public class Response extends CommonObject {
     /**
      * 这个主要用于存储上游传递的一些自定义数据
      */
-    private Map<String, String> meta;
+    private Map<String, Object> meta;
     private String url;
     private Map<String, String> params;
     /**
@@ -87,11 +87,11 @@ public class Response extends CommonObject {
         this.content = content;
     }
 
-    public Map<String, String> getMeta() {
+    public Map<String, Object> getMeta() {
         return meta;
     }
 
-    public void setMeta(Map<String, String> meta) {
+    public void setMeta(Map<String, Object> meta) {
         this.meta = meta;
     }
 


### PR DESCRIPTION
Request 与 Response 中的 meta 变量变成 Map<String, Object> 类型方便传值， #14 
