### PR TITLE
 更改线程池方案,增加springboot下测试用例

### DIFF
--- a/seimicrawler/src/main/java/cn/wanghaomiao/seimi/core/SeimiCrawlerHandler.java
+++ b/seimicrawler/src/main/java/cn/wanghaomiao/seimi/core/SeimiCrawlerHandler.java
@@ -1,0 +1,164 @@
+package cn.wanghaomiao.seimi.core;
+
+import cn.wanghaomiao.seimi.annotation.Interceptor;
+import cn.wanghaomiao.seimi.def.BaseSeimiCrawler;
+import cn.wanghaomiao.seimi.http.SeimiHttpType;
+import cn.wanghaomiao.seimi.http.hc.HcDownloader;
+import cn.wanghaomiao.seimi.http.okhttp.OkHttpDownloader;
+import cn.wanghaomiao.seimi.struct.BodyType;
+import cn.wanghaomiao.seimi.struct.CrawlerModel;
+import cn.wanghaomiao.seimi.struct.Request;
+import cn.wanghaomiao.seimi.struct.Response;
+import cn.wanghaomiao.seimi.utils.StructValidator;
+import com.alibaba.fastjson.JSON;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author github.com/zzldnl
+ * @since 2019/01/24.
+ */
+public class SeimiCrawlerHandler implements Runnable{
+	
+	private Logger logger = LoggerFactory.getLogger(getClass());
+	
+	private Request request;
+	private CrawlerModel crawlerModel;
+	private BaseSeimiCrawler crawler;
+	private SeimiQueue queue;
+	private List<SeimiInterceptor> interceptors;
+	
+	public SeimiCrawlerHandler(Request request, CrawlerModel crawlerModel, List<SeimiInterceptor> interceptors) {
+		// TODO Auto-generated constructor stub
+		this.request=request;
+		this.crawlerModel=crawlerModel;
+		this.crawler = crawlerModel.getInstance();
+		this.queue = crawlerModel.getQueueInstance();
+		this.interceptors = interceptors;
+	}
+	
+	private Pattern metaRefresh = Pattern.compile("<(?:META|meta|Meta)\\s+(?:HTTP-EQUIV|http-equiv)\\s*=\\s*\"refresh\".*(?:url|URL)=(\\S*)\".*/?>");
+
+	@Override
+	public void run() {
+        try {
+            //对请求开始校验
+            if (!StructValidator.validateAnno(request)) {
+                logger.warn("Request={} is illegal", JSON.toJSONString(request));
+                return;
+            }
+            if (!StructValidator.validateAllowRules(crawler.allowRules(), request.getUrl())) {
+                logger.warn("Request={} will be dropped by allowRules=[{}]", JSON.toJSONString(request), StringUtils.join(crawler.allowRules(), ","));
+                return;
+            }
+            if (StructValidator.validateDenyRules(crawler.denyRules(), request.getUrl())) {
+                logger.warn("Request={} will be dropped by denyRules=[{}]", JSON.toJSONString(request), StringUtils.join(crawler.denyRules(), ","));
+                return;
+            }
+            //异常请求重试次数超过最大重试次数三次后，直接放弃处理
+            if (request.getCurrentReqCount() >= request.getMaxReqCount()+3) {
+                return;
+            }
+
+            SeimiDownloader downloader;
+            if (SeimiHttpType.APACHE_HC.val() == crawlerModel.getSeimiHttpType().val()) {
+                downloader = new HcDownloader(crawlerModel);
+            } else {
+                downloader = new OkHttpDownloader(crawlerModel);
+            }
+
+            Response seimiResponse = downloader.process(request);
+            if (StringUtils.isNotBlank(seimiResponse.getContent()) && BodyType.TEXT.equals(seimiResponse.getBodyType())) {
+                Matcher mm = metaRefresh.matcher(seimiResponse.getContent());
+                int refreshCount = 0;
+                while (!request.isUseSeimiAgent() && mm.find() && refreshCount < 3) {
+                    String nextUrl = mm.group(1).replaceAll("'", "");
+                    seimiResponse = downloader.metaRefresh(nextUrl);
+                    mm = metaRefresh.matcher(seimiResponse.getContent());
+                    refreshCount += 1;
+                }
+            }
+            //处理回调函数
+            if (!request.isLambdaCb()){
+                doCallback(request, seimiResponse);
+            }else {
+                doLambdaCallback(request, seimiResponse);
+            }
+            logger.debug("Crawler[{}] ,url={} ,responseStatus={}", crawlerModel.getCrawlerName(), request.getUrl(), downloader.statusCode());
+        } catch (Throwable e) {
+            logger.error(e.getMessage(), e);
+            if (request == null) {
+                return;
+            }
+            if (request.getCurrentReqCount() < request.getMaxReqCount()) {
+                request.incrReqCount();
+                queue.push(request);
+                logger.info("Request process error,req will go into queue again,url={},maxReqCount={},currentReqCount={}", request.getUrl(), request.getMaxReqCount(), request.getCurrentReqCount());
+            } else if (request.getCurrentReqCount() >= request.getMaxReqCount() && request.getMaxReqCount() > 0) {
+                crawler.handleErrorRequest(request);
+            }
+
+        }
+
+	}
+
+    private void doCallback(Request request, Response seimiResponse) throws Exception {
+
+        Method requestCallback = crawlerModel.getMemberMethods().get(request.getCallBack());
+        if (requestCallback == null) {
+            logger.info("can not find callback function");
+            return;
+        }
+        for (SeimiInterceptor interceptor : interceptors) {
+            Interceptor interAnno = interceptor.getClass().getAnnotation(Interceptor.class);
+            if (interAnno.everyMethod() || requestCallback.isAnnotationPresent(interceptor.getTargetAnnotationClass()) || crawlerModel.getClazz().isAnnotationPresent(interceptor.getTargetAnnotationClass())) {
+                interceptor.before(requestCallback, seimiResponse);
+            }
+        }
+        if (crawlerModel.getDelay() > 0) {
+            TimeUnit.SECONDS.sleep(crawlerModel.getDelay());
+        }
+        requestCallback.invoke(crawlerModel.getInstance(), seimiResponse);
+
+        for (SeimiInterceptor interceptor : interceptors) {
+            Interceptor interAnno = interceptor.getClass().getAnnotation(Interceptor.class);
+            if (interAnno.everyMethod() || requestCallback.isAnnotationPresent(interceptor.getTargetAnnotationClass()) || crawlerModel.getClazz().isAnnotationPresent(interceptor.getTargetAnnotationClass())) {
+                interceptor.after(requestCallback, seimiResponse);
+            }
+        }
+    }
+
+    private void doLambdaCallback(Request request, Response seimiResponse) throws Exception {
+        Request.SeimiCallbackFunc<SeimiCrawler,Response> requestCallback = request.getCallBackFunc();
+        if (requestCallback == null) {
+            logger.info("can not find callback function");
+            return;
+        }
+        for (SeimiInterceptor interceptor : interceptors) {
+            Interceptor interAnno = interceptor.getClass().getAnnotation(Interceptor.class);
+            if (interAnno.everyMethod()) {
+                interceptor.before(null, seimiResponse);
+            }
+        }
+        if (crawlerModel.getDelay() > 0) {
+            TimeUnit.SECONDS.sleep(crawlerModel.getDelay());
+        }
+        requestCallback.call(crawler,seimiResponse);
+        for (SeimiInterceptor interceptor : interceptors) {
+            Interceptor interAnno = interceptor.getClass().getAnnotation(Interceptor.class);
+            if (interAnno.everyMethod() ) {
+                interceptor.after(null, seimiResponse);
+            }
+        }
+    }
+	
+	
+}

--- a/seimicrawler/src/main/java/cn/wanghaomiao/seimi/core/SeimiProcessor.java
+++ b/seimicrawler/src/main/java/cn/wanghaomiao/seimi/core/SeimiProcessor.java
@@ -15,25 +15,15 @@
  */
 package cn.wanghaomiao.seimi.core;
 
-import cn.wanghaomiao.seimi.annotation.Interceptor;
+import cn.wanghaomiao.seimi.Constants;
 import cn.wanghaomiao.seimi.def.BaseSeimiCrawler;
-import cn.wanghaomiao.seimi.http.SeimiHttpType;
-import cn.wanghaomiao.seimi.http.hc.HcDownloader;
-import cn.wanghaomiao.seimi.http.okhttp.OkHttpDownloader;
-import cn.wanghaomiao.seimi.struct.BodyType;
 import cn.wanghaomiao.seimi.struct.CrawlerModel;
 import cn.wanghaomiao.seimi.struct.Request;
-import cn.wanghaomiao.seimi.struct.Response;
-import cn.wanghaomiao.seimi.utils.StructValidator;
-import com.alibaba.fastjson.JSON;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Method;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
+import java.util.concurrent.*;
 import java.util.regex.Pattern;
 
 /**
@@ -46,15 +36,16 @@ public class SeimiProcessor implements Runnable {
     private CrawlerModel crawlerModel;
     private BaseSeimiCrawler crawler;
     private Logger logger = LoggerFactory.getLogger(getClass());
+    private ExecutorService workersPool;
 
     public SeimiProcessor(List<SeimiInterceptor> interceptors, CrawlerModel crawlerModel) {
         this.queue = crawlerModel.getQueueInstance();
         this.interceptors = interceptors;
         this.crawlerModel = crawlerModel;
         this.crawler = crawlerModel.getInstance();
+        workersPool = new ThreadPoolExecutor(Runtime.getRuntime().availableProcessors(),Constants.BASE_THREAD_NUM*Runtime.getRuntime().availableProcessors(),
+                3,TimeUnit.SECONDS,new ArrayBlockingQueue(Runtime.getRuntime().availableProcessors()*5),new ThreadPoolExecutor.CallerRunsPolicy());
     }
-
-    private Pattern metaRefresh = Pattern.compile("<(?:META|meta|Meta)\\s+(?:HTTP-EQUIV|http-equiv)\\s*=\\s*\"refresh\".*(?:url|URL)=(\\S*)\".*/?>");
 
     @Override
     public void run() {
@@ -65,6 +56,7 @@ public class SeimiProcessor implements Runnable {
                 if (request == null) {
                     continue;
                 }
+                logger.debug("SeimiProcessor({}-{})[url:{}]",request.getCrawlerName(),request.getCallBack(),request.getUrl());
                 if (crawlerModel == null) {
                     logger.error("No such crawler name:'{}'", request.getCrawlerName());
                     continue;
@@ -73,112 +65,10 @@ public class SeimiProcessor implements Runnable {
                     logger.info("SeimiProcessor[{}] will stop!", Thread.currentThread().getName());
                     break;
                 }
-                //对请求开始校验
-                if (!StructValidator.validateAnno(request)) {
-                    logger.warn("Request={} is illegal", JSON.toJSONString(request));
-                    continue;
-                }
-                if (!StructValidator.validateAllowRules(crawler.allowRules(), request.getUrl())) {
-                    logger.warn("Request={} will be dropped by allowRules=[{}]", JSON.toJSONString(request), StringUtils.join(crawler.allowRules(), ","));
-                    continue;
-                }
-                if (StructValidator.validateDenyRules(crawler.denyRules(), request.getUrl())) {
-                    logger.warn("Request={} will be dropped by denyRules=[{}]", JSON.toJSONString(request), StringUtils.join(crawler.denyRules(), ","));
-                    continue;
-                }
-                //异常请求重试次数超过最大重试次数三次后，直接放弃处理
-                if (request.getCurrentReqCount() >= request.getMaxReqCount()+3) {
-                    continue;
-                }
-
-                SeimiDownloader downloader;
-                if (SeimiHttpType.APACHE_HC.val() == crawlerModel.getSeimiHttpType().val()) {
-                    downloader = new HcDownloader(crawlerModel);
-                } else {
-                    downloader = new OkHttpDownloader(crawlerModel);
-                }
-
-                Response seimiResponse = downloader.process(request);
-                if (StringUtils.isNotBlank(seimiResponse.getContent()) && BodyType.TEXT.equals(seimiResponse.getBodyType())) {
-                    Matcher mm = metaRefresh.matcher(seimiResponse.getContent());
-                    int refreshCount = 0;
-                    while (!request.isUseSeimiAgent() && mm.find() && refreshCount < 3) {
-                        String nextUrl = mm.group(1).replaceAll("'", "");
-                        seimiResponse = downloader.metaRefresh(nextUrl);
-                        mm = metaRefresh.matcher(seimiResponse.getContent());
-                        refreshCount += 1;
-                    }
-                }
-                //处理回调函数
-                if (!request.isLambdaCb()){
-                    doCallback(request, seimiResponse);
-                }else {
-                    doLambdaCallback(request, seimiResponse);
-                }
-                logger.debug("Crawler[{}] ,url={} ,responseStatus={}", crawlerModel.getCrawlerName(), request.getUrl(), downloader.statusCode());
-            } catch (Throwable e) {
-                logger.error(e.getMessage(), e);
-                if (request == null) {
-                    continue;
-                }
-                if (request.getCurrentReqCount() < request.getMaxReqCount()) {
-                    request.incrReqCount();
-                    queue.push(request);
-                    logger.info("Request process error,req will go into queue again,url={},maxReqCount={},currentReqCount={}", request.getUrl(), request.getMaxReqCount(), request.getCurrentReqCount());
-                } else if (request.getCurrentReqCount() >= request.getMaxReqCount() && request.getMaxReqCount() > 0) {
-                    crawler.handleErrorRequest(request);
-                }
-
-            }
-        }
-    }
-
-    private void doCallback(Request request, Response seimiResponse) throws Exception {
-
-        Method requestCallback = crawlerModel.getMemberMethods().get(request.getCallBack());
-        if (requestCallback == null) {
-            logger.info("can not find callback function");
-            return;
-        }
-        for (SeimiInterceptor interceptor : interceptors) {
-            Interceptor interAnno = interceptor.getClass().getAnnotation(Interceptor.class);
-            if (interAnno.everyMethod() || requestCallback.isAnnotationPresent(interceptor.getTargetAnnotationClass()) || crawlerModel.getClazz().isAnnotationPresent(interceptor.getTargetAnnotationClass())) {
-                interceptor.before(requestCallback, seimiResponse);
-            }
-        }
-        if (crawlerModel.getDelay() > 0) {
-            TimeUnit.SECONDS.sleep(crawlerModel.getDelay());
-        }
-        requestCallback.invoke(crawlerModel.getInstance(), seimiResponse);
-
-        for (SeimiInterceptor interceptor : interceptors) {
-            Interceptor interAnno = interceptor.getClass().getAnnotation(Interceptor.class);
-            if (interAnno.everyMethod() || requestCallback.isAnnotationPresent(interceptor.getTargetAnnotationClass()) || crawlerModel.getClazz().isAnnotationPresent(interceptor.getTargetAnnotationClass())) {
-                interceptor.after(requestCallback, seimiResponse);
-            }
-        }
-    }
-
-    private void doLambdaCallback(Request request, Response seimiResponse) throws Exception {
-        Request.SeimiCallbackFunc<SeimiCrawler,Response> requestCallback = request.getCallBackFunc();
-        if (requestCallback == null) {
-            logger.info("can not find callback function");
-            return;
-        }
-        for (SeimiInterceptor interceptor : interceptors) {
-            Interceptor interAnno = interceptor.getClass().getAnnotation(Interceptor.class);
-            if (interAnno.everyMethod()) {
-                interceptor.before(null, seimiResponse);
-            }
-        }
-        if (crawlerModel.getDelay() > 0) {
-            TimeUnit.SECONDS.sleep(crawlerModel.getDelay());
-        }
-        requestCallback.call(crawler,seimiResponse);
-        for (SeimiInterceptor interceptor : interceptors) {
-            Interceptor interAnno = interceptor.getClass().getAnnotation(Interceptor.class);
-            if (interAnno.everyMethod() ) {
-                interceptor.after(null, seimiResponse);
+                workersPool.submit(new SeimiCrawlerHandler(request, crawlerModel, interceptors));
+            } catch (Exception e) {
+                logger.error("redission queue exception!",e);
+                return;
             }
         }
     }

--- a/seimicrawler/src/main/java/cn/wanghaomiao/seimi/core/SeimiQueue.java
+++ b/seimicrawler/src/main/java/cn/wanghaomiao/seimi/core/SeimiQueue.java
@@ -30,7 +30,7 @@ public interface SeimiQueue extends Serializable {
      * @param crawlerName --
      * @return --
      */
-    Request bPop(String crawlerName);
+    Request bPop(String crawlerName) throws Exception;
     /**
      * 入队一个请求
      * @param req 请求

--- a/seimicrawler/src/main/java/cn/wanghaomiao/seimi/def/DefaultRedisQueue.java
+++ b/seimicrawler/src/main/java/cn/wanghaomiao/seimi/def/DefaultRedisQueue.java
@@ -98,15 +98,9 @@ public class DefaultRedisQueue implements SeimiQueue {
     }
 
     @Override
-    public Request bPop(String crawlerName) {
-        Request request = null;
-        try {
-            RBlockingQueue<Request> rBlockingQueue = getQueue(crawlerName);
-            request = rBlockingQueue.take();
-        } catch (Exception e) {
-            logger.warn(e.getMessage(), e);
-        }
-        return request;
+    public Request bPop(String crawlerName) throws InterruptedException {
+        RBlockingQueue<Request> rBlockingQueue = getQueue(crawlerName);
+        return rBlockingQueue.take();
     }
 
     @Override

--- a/seimicrawler/src/main/java/cn/wanghaomiao/seimi/spring/common/SeimiCrawlerBootstrapListener.java
+++ b/seimicrawler/src/main/java/cn/wanghaomiao/seimi/spring/common/SeimiCrawlerBootstrapListener.java
@@ -19,6 +19,7 @@ import org.springframework.util.CollectionUtils;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 /**
  * @author: github.com/zhegexiaohuozi seimimaster@gmail.com
@@ -61,7 +62,8 @@ public class SeimiCrawlerBootstrapListener implements ApplicationListener<Contex
                 logger.info("Not find any crawler,may be you need to check.");
                 return;
             }
-            workersPool = Executors.newFixedThreadPool(Constants.BASE_THREAD_NUM * Runtime.getRuntime().availableProcessors() * CrawlerCache.getCrawlers().size());
+            workersPool = new ScheduledThreadPoolExecutor(CrawlerCache.getCrawlers().size());
+//            workersPool = Executors.newFixedThreadPool(Constants.BASE_THREAD_NUM * Runtime.getRuntime().availableProcessors() * CrawlerCache.getCrawlers().size());
             for (Class<? extends BaseSeimiCrawler> a : CrawlerCache.getCrawlers()) {
                 CrawlerModel crawlerModel = new CrawlerModel(a, context);
                 if (CrawlerCache.isExist(crawlerModel.getCrawlerName())) {
@@ -72,9 +74,9 @@ public class SeimiCrawlerBootstrapListener implements ApplicationListener<Contex
             }
 
             for (Map.Entry<String, CrawlerModel> crawlerEntry : CrawlerCache.getCrawlerModelContext().entrySet()) {
-                for (int i = 0; i < Constants.BASE_THREAD_NUM * Runtime.getRuntime().availableProcessors(); i++) {
+//                for (int i = 0; i < Constants.BASE_THREAD_NUM * Runtime.getRuntime().availableProcessors(); i++) {
                     workersPool.execute(new SeimiProcessor(CrawlerCache.getInterceptors(), crawlerEntry.getValue()));
-                }
+//                }
             }
 
             if (isSpringBoot){

--- a/spring-boot-example/src/test/java/cn/wanghaomiao/seimi/crawlers/BasicTest.java
+++ b/spring-boot-example/src/test/java/cn/wanghaomiao/seimi/crawlers/BasicTest.java
@@ -1,0 +1,28 @@
+package cn.wanghaomiao.seimi.crawlers;
+
+import cn.wanghaomiao.seimi.spring.common.CrawlerCache;
+import cn.wanghaomiao.seimi.struct.Request;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest()
+public class BasicTest {
+
+    @Test
+    public void startTest(){
+
+        CrawlerCache.consumeRequest(Request.build("http://www.cnblogs.com/","start").setCrawlerName("basic_a"));
+        try {
+            Thread.sleep(1000*30);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+}


### PR DESCRIPTION
更改核心线程池方案，由原来一个crawler多个线程从队列中取抓取请求，改为一个crawler一个线程从队列里取抓取请求，再丢到crawler自己的线程池中处理。